### PR TITLE
feat: Add support to start from some initial position

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 	implementation 'org.jdbi:jdbi3-core:3.8.0'
 	implementation 'org.jdbi:jdbi3-kotlin:3.8.0'
 	implementation 'org.jdbi:jdbi3-kotlin-sqlobject:3.8.0'
+	implementation 'org.flywaydb:flyway-core:6.0.8'
 	testImplementation("org.springframework.boot:spring-boot-starter-test:${springBootVersion}") {
 		exclude(group: 'org.junit')
 	}

--- a/src/main/kotlin/io/inventi/eventstore/eventhandler/IdempotentEventHandler.kt
+++ b/src/main/kotlin/io/inventi/eventstore/eventhandler/IdempotentEventHandler.kt
@@ -72,7 +72,9 @@ abstract class IdempotentEventHandler(
 
     private var running: Boolean = false
 
-    private var firstEventNumberToHandle: Long = -1
+    private val firstEventNumberToHandle: Long by lazy {
+        initialPosition.getFirstEventNumberToHandle(eventStore, objectMapper)
+    }
 
     constructor(
             streamName: String,
@@ -92,7 +94,6 @@ abstract class IdempotentEventHandler(
     override fun start() {
         ensureSubscription()
 
-        firstEventNumberToHandle = initialPosition.getFirstEventNumberToHandle(eventStore, objectMapper)
 
         val persistentSubscription = object : PersistentSubscriptionListener {
 

--- a/src/main/kotlin/io/inventi/eventstore/eventhandler/IdempotentEventHandler.kt
+++ b/src/main/kotlin/io/inventi/eventstore/eventhandler/IdempotentEventHandler.kt
@@ -18,6 +18,7 @@ import io.inventi.eventstore.eventhandler.exception.UnsupportedMethodException
 import io.inventi.eventstore.eventhandler.model.IdempotentEventClassifierRecord
 import io.inventi.eventstore.eventhandler.model.MethodParametersType
 import io.inventi.eventstore.util.LoggerDelegate
+import org.flywaydb.core.Flyway
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
@@ -62,6 +63,11 @@ abstract class IdempotentEventHandler(
 
     @Autowired
     private var subscriptionProperties: SubscriptionProperties = SubscriptionProperties()
+
+    @Autowired
+    @Suppress("UNUSED")
+    // We should make sure we start AFTER flyway has done it's job
+    private lateinit var flyway: Flyway
 
     private var running: Boolean = false
 

--- a/src/main/kotlin/io/inventi/eventstore/eventhandler/InitialPosition.kt
+++ b/src/main/kotlin/io/inventi/eventstore/eventhandler/InitialPosition.kt
@@ -1,0 +1,31 @@
+package io.inventi.eventstore.eventhandler
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.github.msemys.esjc.EventStore
+import com.github.msemys.esjc.StreamPosition
+
+
+sealed class InitialPosition {
+    abstract fun getFirstEventNumberToHandle(eventStore: EventStore, objectMapper: ObjectMapper): Long
+
+    class FromBeginning : InitialPosition() {
+        override fun getFirstEventNumberToHandle(eventStore: EventStore, objectMapper: ObjectMapper): Long {
+            return StreamPosition.START
+        }
+    }
+
+    class TakeOverPersistentSubscription(
+            val streamName: String,
+            val groupName: String
+    ) : InitialPosition() {
+        override fun getFirstEventNumberToHandle(eventStore: EventStore, objectMapper: ObjectMapper): Long {
+            val subscriptionCheckpointStream = "\$persistentsubscription-$streamName::$groupName-checkpoint"
+            val readResult = eventStore.readEvent(subscriptionCheckpointStream, StreamPosition.END, true).join()
+
+            val oldPosition = objectMapper.readValue<Long>(readResult.event.event.data)
+
+            return oldPosition + 1
+        }
+    }
+}

--- a/src/main/kotlin/io/inventi/eventstore/eventhandler/annotation/EventHandler.kt
+++ b/src/main/kotlin/io/inventi/eventstore/eventhandler/annotation/EventHandler.kt
@@ -3,4 +3,4 @@ package io.inventi.eventstore.eventhandler.annotation
 
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class EventHandler
+annotation class EventHandler(val skipWhenReplaying: Boolean = false)


### PR DESCRIPTION
Currently, FromBeginning and TakeOverPersistentSubscription are supported:
- FromBeginning starts from stream beginning
- TakeOverPersistentSubscription starts from where another subscription
  has stopped.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inventi/eventstore-tools/10)
<!-- Reviewable:end -->
