### PR TITLE
feat(IdempotentEventHandler): Use `transformedFromJavaId` metadata field as event id if it exists

### DIFF
--- a/src/test/kotlin/io/inventi/eventstore/eventhandler/ConditionalOnSubscriptionsEnabledTest.kt
+++ b/src/test/kotlin/io/inventi/eventstore/eventhandler/ConditionalOnSubscriptionsEnabledTest.kt
@@ -20,7 +20,7 @@ import org.springframework.test.context.junit4.SpringRunner
 )
 class ConditionalOnSubscriptionsEnabledTest {
     @Autowired
-    var handler: IdempotentEventHandlerTest.SomeHandler? = null
+    private var handler: IdempotentEventHandlerTest.SomeHandler? = null
 
     @Test
     fun `does not instantiate bean if eventstore subscriptions enabled is false`() {


### PR DESCRIPTION
This way, when we do copy&replace, we set this field to eventId
so old events don't get re-applied.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inventi/eventstore-tools/15)
<!-- Reviewable:end -->
