### PR TITLE
fix(BOS-133): add user initiated as recoverable subscription drop reason

### DIFF
--- a/src/main/kotlin/io/inventi/eventstore/eventhandler/IdempotentPersistentSubscriptionListener.kt
+++ b/src/main/kotlin/io/inventi/eventstore/eventhandler/IdempotentPersistentSubscriptionListener.kt
@@ -40,7 +40,8 @@ internal class IdempotentPersistentSubscriptionListener(
                 SubscriptionDropReason.ConnectionClosed,
                 SubscriptionDropReason.ServerError,
                 SubscriptionDropReason.SubscribingError,
-                SubscriptionDropReason.CatchUpError
+                SubscriptionDropReason.CatchUpError,
+                SubscriptionDropReason.UserInitiated
         )
     }
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inventi/eventstore-tools/26)
<!-- Reviewable:end -->
