### PR TITLE
feat(BO-1732): remove java version check

### DIFF
--- a/src/main/kotlin/io/inventi/eventstore/util/script/CopyAndReplaceUtils.kt
+++ b/src/main/kotlin/io/inventi/eventstore/util/script/CopyAndReplaceUtils.kt
@@ -69,10 +69,6 @@ fun withEventStore(
         objectMapper: ObjectMapper = ObjectMapperFactory.createDefaultObjectMapper(),
         block: CopyAndReplaceOperation.(eventStore: EventStore) -> Unit,
 ) {
-    if (!System.getProperty("java.version").startsWith("1.8")) {
-        throw IllegalStateException("Only Java 8 is supported. ESJC uses GSON which fails to load java.sql.Time class on Java 11.")
-    }
-
     val eventStore = EventStoreBuilder.newBuilder()
             .maxReconnections(3)
             .heartbeatTimeout(Duration.ofSeconds(10))


### PR DESCRIPTION
1. Eventstore-Tools are used in Conventions-MS. Conventions-MS use java 11 version which clashes with Eventstore-Tools java 8 version when doing copy and replace

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inventi/eventstore-tools/37)
<!-- Reviewable:end -->
