### PR TITLE
feat(1681): Add support to start first event number to handle from the end of stream

### DIFF
--- a/src/main/kotlin/io/inventi/eventstore/eventhandler/InitialPosition.kt
+++ b/src/main/kotlin/io/inventi/eventstore/eventhandler/InitialPosition.kt
@@ -34,4 +34,14 @@ sealed class InitialPosition {
             private const val DEFAULT_START_POSITION = StreamPosition.START
         }
     }
+
+    class FromTheEndOfStream(
+        private val streamName: String,
+    ) : InitialPosition() {
+        override fun getFirstEventNumberToHandle(eventStore: EventStore, objectMapper: ObjectMapper): Long {
+            val readResult = eventStore.readEvent(streamName, StreamPosition.END, true).join()
+
+            return readResult.event.link.eventNumber
+        }
+    }
 }

--- a/src/main/kotlin/io/inventi/eventstore/eventhandler/InitialPosition.kt
+++ b/src/main/kotlin/io/inventi/eventstore/eventhandler/InitialPosition.kt
@@ -41,7 +41,7 @@ sealed class InitialPosition {
         override fun getFirstEventNumberToHandle(eventStore: EventStore, objectMapper: ObjectMapper): Long {
             val readResult = eventStore.readEvent(streamName, StreamPosition.END, true).join()
 
-            return readResult.event.link.eventNumber
+            return readResult.event.originalEventNumber()
         }
     }
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inventi/eventstore-tools/39)
<!-- Reviewable:end -->
