### PR TITLE
fix(BOS-321): yield leadership when connection to eventstore fails

### DIFF
--- a/src/main/kotlin/io/inventi/eventstore/eventhandler/CatchupSubscriptions.kt
+++ b/src/main/kotlin/io/inventi/eventstore/eventhandler/CatchupSubscriptions.kt
@@ -110,7 +110,15 @@ class CatchupSubscriptions(
     fun handleEvent(event: OnGrantedEvent) {
         logger.info("Received catch-up subscription leadership for role: ${event.role}. Starting subscriptions...")
         isLeader = true
-        startSubscriptions()
+        try {
+            startSubscriptions()
+        } catch (exception: Exception) {
+            logger.warn(
+                "Revoking catch-up subscription leadership for role: ${event.role} because leader could not start subscriptions...",
+                exception
+            )
+            event.context.yield()
+        }
     }
 
     @EventListener

--- a/src/test/kotlin/io/inventi/eventstore/eventhandler/CatchupSubscriptionsLeadershipElectionTest.kt
+++ b/src/test/kotlin/io/inventi/eventstore/eventhandler/CatchupSubscriptionsLeadershipElectionTest.kt
@@ -1,0 +1,45 @@
+package io.inventi.eventstore.eventhandler
+
+import com.github.msemys.esjc.EventStoreException
+import io.inventi.eventstore.eventhandler.config.SubscriptionProperties
+import io.inventi.eventstore.eventhandler.util.DataBuilder
+import io.mockk.*
+import org.junit.jupiter.api.Test
+import org.springframework.integration.leader.event.OnGrantedEvent
+
+class CatchupSubscriptionsLeadershipElectionTest {
+    private val onGrantedEvent = mockk<OnGrantedEvent> {
+        every { role } returns "someRole"
+        every { context.yield() } just Runs
+    }
+
+    private val catchupSubscriptions = CatchupSubscriptions(
+        handlers = listOf(FailingLeaderElectionHandler()),
+        eventStore = mockk(),
+        objectMapper = mockk(),
+        subscriptionCheckpointDao = mockk(),
+        subscriptionInitialPositionDao = mockk(),
+        transactionTemplate = mockk(),
+        idempotencyStorage = mockk(),
+        properties = SubscriptionProperties(),
+        meterRegistry = null,
+    )
+
+    @Test
+    fun `yields leadership when granted leadership handling fails with exceptions`() {
+        // when
+        catchupSubscriptions.handleEvent(onGrantedEvent)
+
+        // then
+        verify(exactly = 1) { onGrantedEvent.context.yield() }
+    }
+
+    private class FailingLeaderElectionHandler(
+        override val streamName: String = DataBuilder.streamName,
+        override val groupName: String = DataBuilder.groupName,
+    ) : CatchupSubscriptionHandler {
+        override val initialPosition = mockk<InitialPosition> {
+            every { startSubscriptionFrom(any(), any()) } throws EventStoreException("Some message")
+        }
+    }
+}


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inventi/eventstore-tools/51)
<!-- Reviewable:end -->
